### PR TITLE
Primary domain

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseURL = "https://mateybyrd.github.io/docs/"
+baseURL = "https://wiki.nickbelzer.me/"
 languageCode = "en-us"
 title = "Nick's Documentation"
 theme = "docs"

--- a/static/CNAME
+++ b/static/CNAME
@@ -1,0 +1,1 @@
+wiki.nickbelzer.me


### PR DESCRIPTION
Resolves #1 

Allows the Github Pages version of this repo to be accessed through a custom domain. The custom domain chosen is `https://wiki.nickbelzer.me`.

**Changelog**
- Add custom `CNAME` file to set a custom domain for Github Pages as described on their [docs](https://help.github.com/en/github/working-with-github-pages/managing-a-custom-domain-for-your-github-pages-site).
- Changes the `baseURL` property to match with the custom domain.

